### PR TITLE
Fix template name reference

### DIFF
--- a/DependencyInjection/Compiler/TwigFormPass.php
+++ b/DependencyInjection/Compiler/TwigFormPass.php
@@ -14,7 +14,7 @@ class TwigFormPass implements CompilerPassInterface
         }
 
         $container->setParameter('twig.form.resources', array_merge(
-            ['NorzechowiczAceEditorBundle:Form:div_layout.html.twig'],
+            ['@NorzechowiczAceEditor/Form/div_layout.html.twig'],
             $container->getParameter('twig.form.resources')
         ));
     }


### PR DESCRIPTION
This change fixes symfony error 

`Unable to find template "NorzechowiczAceEditorBundle:Form:div_layout.html.twig" (looked into: /home/zim32/www/code/app/Resources/views, /home/zim32/www/code/vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form).`